### PR TITLE
Re-implement caching using aiocache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "regex>=2024.4.28",
     "pyicu>=2.15",
     "aiohttp>=3.12.15",
+    "aiocache>=0.12.3",
 ]
 readme = "README.md"
 requires-python = ">= 3.12, < 3.14"

--- a/stas_server/process.py
+++ b/stas_server/process.py
@@ -1,14 +1,11 @@
 from icu import Locale, BreakIterator
 import regex as re
 
-import stas_server.config as config
-from stas_server.util import lru_cache_ext
-
 locale = Locale("ja_JP")
 break_iterator = BreakIterator.createSentenceInstance(locale)
 
 
-def split_jp_core(text: str):
+def split_jp(text: str):
     break_iterator.setText(text)
     segmented_sentences: list[str] = []
     last_pos = 0
@@ -23,16 +20,13 @@ def split_jp_core(text: str):
 
 newline_regex = re.compile(r"(\n+)")
 
-# This decorator will add enable_cache kwargs to the function; Only relevant to decorator.
-split_jp = lru_cache_ext(maxsize=None)(split_jp_core)
-
 
 def split_sentences_in_batch(text_list: list[str]):
     final_text_list: list[str] = []
     text_map: list[int] = []
 
     for text in text_list:
-        split_text_list = [str(i) for i in split_jp(text, enable_cache=config.cache)]
+        split_text_list = [str(i) for i in split_jp(text)]
         final_text_list.extend(split_text_list)
         text_map.append(len(split_text_list))
 

--- a/stas_server/translation.py
+++ b/stas_server/translation.py
@@ -9,7 +9,6 @@ from ctranslate2 import Translator
 
 import stas_server.config as config
 from stas_server.util import (
-    lru_cache_ext,
     split_list_by_condition,
     flatten_2d_list,
     recombine_split_list,
@@ -73,8 +72,6 @@ def setup_translation():
     )
 
 
-# This decorator will add enable_cache kwargs to the function; Only relevant to decorator.
-@lru_cache_ext(maxsize=None)
 def core_translator(text_list: list[str]):
     text_list = spe.Encode(text_list, out_type=str)
     result = translator.translate_batch(
@@ -102,7 +99,7 @@ def common_translator(batch_content: list[str]):
             strip_bracket(c) if in_queue_state[i][0] else c
             for i, c in enumerate(in_queue_list)
         ]
-        result_list = core_translator(in_queue_list, enable_cache=config.cache)
+        result_list = core_translator(in_queue_list)
         log_translation.info(f"Result In Queue: {result_list}")
         result_list = [post_clean(r) for r in result_list]
         result_list = [
@@ -117,7 +114,7 @@ def common_translator(batch_content: list[str]):
             for i, r in enumerate(result_list)
         ]
     else:
-        result_list = core_translator(in_queue_list, enable_cache=config.cache)
+        result_list = core_translator(in_queue_list)
         result_list = [post_clean(result_list[0])]
         result = restore_original_state(
             result_list[0],

--- a/stas_server/util.py
+++ b/stas_server/util.py
@@ -1,4 +1,5 @@
-from typing import Callable, Literal
+import asyncio
+from typing import Callable, Awaitable, Literal
 
 
 def process_raw_string(text: str):
@@ -12,6 +13,27 @@ def split_list_by_condition[T](obj_list: list[T], condition: Callable[[T], bool]
 
     for o in obj_list:
         if condition(o):
+            split_list.append(o)
+            list_index.append("D")
+        else:
+            leftover_list.append(o)
+            list_index.append("L")
+
+    return split_list, leftover_list, list_index
+
+
+async def split_list_by_async_condition[T](
+    obj_list: list[T], condition: Callable[[T], Awaitable[bool]]
+):
+    split_list: list[T] = []
+    leftover_list: list[T] = []
+    list_index: list[Literal["D", "L"]] = []
+
+    tasks = [condition(o) for o in obj_list]
+    results = await asyncio.gather(*tasks)
+
+    for i, o in enumerate(obj_list):
+        if results[i]:
             split_list.append(o)
             list_index.append("D")
         else:

--- a/stas_server/util.py
+++ b/stas_server/util.py
@@ -1,5 +1,4 @@
-from functools import _CacheInfo, lru_cache
-from typing import Any, Callable, Literal, ParamSpec, TypeVar
+from typing import Callable, Literal
 
 
 def process_raw_string(text: str):
@@ -46,72 +45,3 @@ def deflate_flat_list[T](flat_list: list[T], list_index: list[int]):
         current_pointer += item
 
     return deflate_list
-
-
-# Based on solution of this question on StackOverflow
-# https://stackoverflow.com/a/73517775
-def hash_list(li: list) -> int:
-    __hash = 0
-    for i, e in enumerate(li):
-        __hash = hash((__hash, i, hash_item(e)))
-    return __hash
-
-
-def hash_item(e) -> int:
-    if hasattr(e, "__hash__") and callable(e.__hash__):
-        try:
-            return hash(e)
-        except TypeError:
-            pass
-    if isinstance(e, (list, set, tuple)):
-        return hash_list(list(e))
-    else:
-        raise TypeError(f"unhashable type: {e.__class__}")
-
-
-PT = ParamSpec("PT")
-RT = TypeVar("RT")
-
-
-def lru_cache_ext(
-    *opts, hashfunc: Callable[..., int] = hash_item, **kwopts
-) -> Callable[[Callable[PT, RT]], Callable[PT, RT]]:
-    def decorator(func: Callable[PT, RT]) -> Callable[PT, RT]:
-        class _lru_cache_ext_wrapper:
-            args: tuple
-            kwargs: dict[str, Any]
-
-            def cache_info(self) -> _CacheInfo: ...
-            def cache_clear(self) -> None: ...
-
-            @classmethod
-            @lru_cache(*opts, **kwopts)
-            def cached_func(cls, args_hash: int) -> RT:
-                return func(*cls.args, **cls.kwargs)
-
-            @classmethod
-            def __call__(cls, *args: PT.args, **kwargs: PT.kwargs) -> RT:
-                if kwargs.get("enable_cache"):
-                    kwargs.pop("enable_cache")
-                    __hash = hashfunc(
-                        (
-                            id(func),
-                            *[hashfunc(a) for a in args],
-                            *[(hashfunc(k), hashfunc(v)) for k, v in kwargs.items()],
-                        )
-                    )
-
-                    cls.args = args
-                    cls.kwargs = kwargs
-
-                    cls.cache_info = cls.cached_func.cache_info
-                    cls.cache_clear = cls.cached_func.cache_clear
-
-                    return cls.cached_func(__hash)
-                else:
-                    kwargs.pop("enable_cache")
-                    return func(*args, **kwargs)
-
-        return _lru_cache_ext_wrapper()
-
-    return decorator

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12, <3.14"
 
 [[package]]
+name = "aiocache"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/64/b945b8025a9d1e6e2138845f4022165d3b337f55f50984fbc6a4c0a1e355/aiocache-0.12.3.tar.gz", hash = "sha256:f528b27bf4d436b497a1d0d1a8f59a542c153ab1e37c3621713cb376d44c4713", size = 132196, upload-time = "2024-09-25T13:20:23.823Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d7/15d67e05b235d1ed8c3ce61688fe4d84130e72af1657acadfaac3479f4cf/aiocache-0.12.3-py2.py3-none-any.whl", hash = "sha256:889086fc24710f431937b87ad3720a289f7fc31c4fd8b68e9f918b9bacd8270d", size = 28199, upload-time = "2024-09-25T13:20:22.688Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -455,9 +464,10 @@ wheels = [
 
 [[package]]
 name = "stas-server"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiocache" },
     { name = "aiohttp" },
     { name = "ctranslate2" },
     { name = "pyicu" },
@@ -467,6 +477,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiocache", specifier = ">=0.12.3" },
     { name = "aiohttp", specifier = ">=3.12.15" },
     { name = "ctranslate2", specifier = ">=4.2.1" },
     { name = "pyicu", specifier = ">=2.15" },


### PR DESCRIPTION
Implement caching using aiocache instead of the standard library functools lru_cache. lru_cache weakness is that it is on a function level and will hash function props only. So, in text batch, even if there are some translations already cached or the position of text in the array is a little different, it is treated as a new entry... aiocache solves this by giving more control on caching, and also an async-safe solution.

I also implement caching at the server level instead of the previous core_translator level and split_jp_core level. No need to enter the translation function.